### PR TITLE
Allows local images to be used in slidee decks

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.15.1
       - run: npm ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: 16.15.1
       - run: npm ci
       - run: npm link
-      - run: npx slidee &
+      - run: npx slidee & sleep 5 && curl http://localhost:3000 -I

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: 16.15.1
       - run: npm ci
       - run: npm link
-      - run: npx slidee
+      - run: npx slidee &

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ app.set("views", path.join(__dirname, 'views'))
 app.use("/", homeRoute);
 app.use("/decks", decksRoute);
 
+// This express.static middleware will catch requests for "assets" i.e. the reveal.js JS and CSS files.
 app.use(express.static(path.join(__dirname, 'public')));
 
 module.exports = app;

--- a/controllers/decks.js
+++ b/controllers/decks.js
@@ -19,7 +19,8 @@ async function index(req, res) {
 
 async function show(req, res) {
     try {
-        const deck = await decks.find({ id: req.path.substr(1) });
+        const deckId = req.path.substr(1); // strips the leading "/" that appears at the start of the path
+        const deck = await decks.find({ id: deckId });
         const content = fs.readFileSync(path.normalize(`${deck.path}`), "utf8");
         res.render("deck", { markdown: content, styles: customStyles });
     } catch (e) {

--- a/controllers/decks.js
+++ b/controllers/decks.js
@@ -19,7 +19,7 @@ async function index(req, res) {
 
 async function show(req, res) {
     try {
-        const deck = await decks.find({ id: req.params.deckId });
+        const deck = await decks.find({ id: req.path.substr(1) });
         const content = fs.readFileSync(path.normalize(`${deck.path}`), "utf8");
         res.render("deck", { markdown: content, styles: customStyles });
     } catch (e) {

--- a/models/decks.js
+++ b/models/decks.js
@@ -66,7 +66,7 @@ function generateDecksData(decksDir, decksRegex) {
             .split(path.sep);
 
         // Creates unique deckId based on filename and directory location
-        const deckId = filePathArray.join("-");
+        const deckId = filePathArray.join("/");
         if (deckData[deckId]) {
             throw new Error(
                 `Two files have the same name after their extensions have been stripped. Please rename them. Look at files ${filePath} and ${deckData[deckId].path}`

--- a/models/decks.js
+++ b/models/decks.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const args = process.argv.slice(2);
 
-// What folder are you slide decks located?
+// What folder are your slide decks located?
 let decksDir = args[0] || process.env.SLIDEE_FOLDER || ".";
 if (decksDir[decksDir.length - 1] === path.sep) {
     decksDir = decksDir.substring(0, decksDir.length - 1);

--- a/models/decks.js
+++ b/models/decks.js
@@ -64,9 +64,13 @@ function generateDecksData(decksDir, decksRegex) {
             .split(decksDir + path.sep)
             .pop()
             .split(path.sep);
+            console.log(filePath)
 
         // Creates unique deckId based on filename and directory location
-        const deckId = filePathArray.join("/");
+        // Previous versions of slidee used "-" character for the join below but
+        // this prevented users from being able to reference local images from slide
+        // decks. Using path.sep allows local images to be used.
+        const deckId = filePathArray.join(path.sep);
         if (deckData[deckId]) {
             throw new Error(
                 `Two files have the same name after their extensions have been stripped. Please rename them. Look at files ${filePath} and ${deckData[deckId].path}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "vite": "^3.0.9"
       },
       "bin": {
-        "slidee": "node index.js"
+        "slidee": "index.js"
       }
     },
     "node_modules/@esbuild/linux-loong64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slidee",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slidee",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "vite": "^3.0.9"
       },
       "bin": {
-        "slidee": "index.js"
+        "slidee": "node index.js"
       }
     },
     "node_modules/@esbuild/linux-loong64": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve": "nodemon index.js"
   },
   "bin": {
-    "slidee": "index.js"
+    "slidee": "node index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve": "nodemon index.js"
   },
   "bin": {
-    "slidee": "node index.js"
+    "slidee": "index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slidee",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Presentation tool powered by Reveal.js",
   "main": "index.js",
   "scripts": {

--- a/routes/decks.js
+++ b/routes/decks.js
@@ -3,12 +3,12 @@ const express = require("express");
 
 const decksController = require("../controllers/decks");
 
+router.get("/", decksController.index);
+
 // This express.static middleware allows local images to be used in the markdown files.
 // The route directory that the files are served from is the directory that slidee is 
 // launched from.
 router.use(express.static("./"));
-
-router.get("/", decksController.index);
 
 // This catch all route is required in order to serve slide decks in a way that
 // mirrors the file/folder structure on the users computer.

--- a/routes/decks.js
+++ b/routes/decks.js
@@ -3,8 +3,17 @@ const express = require("express");
 
 const decksController = require("../controllers/decks");
 
+// This express.static middleware allows local images to be used in the markdown files.
+// The route directory that the files are served from is the directory that slidee is 
+// launched from.
 router.use(express.static("./"));
+
 router.get("/", decksController.index);
+
+// This catch all route is required in order to serve slide decks in a way that
+// mirrors the file/folder structure on the users computer.
+// It is also required for local images to be served relative to the markdown file 
+// in which they are referenced.
 router.get("/*", decksController.show);
 
 

--- a/routes/decks.js
+++ b/routes/decks.js
@@ -1,8 +1,11 @@
 const router = require("express").Router();
+const express = require("express");
 
 const decksController = require("../controllers/decks");
 
+router.use(express.static("./"));
 router.get("/", decksController.index);
-router.get("/:deckId", decksController.show);
+router.get("/*", decksController.show);
+
 
 module.exports = router;


### PR DESCRIPTION
Refactored the codebase to make the slidee deckIDs to mirror the file/folder structure of where the markdown files live. This allows local images to be referenced in `<img>` tags.